### PR TITLE
XBOX 360 LED support

### DIFF
--- a/include/xinput.h
+++ b/include/xinput.h
@@ -31,6 +31,22 @@
 #define XINPUT_SUBTYPE_GUITAR_BASS      0x0B
 #define XINPUT_SUBTYPE_ARCADE_PAD       0x13
 
+// XBOX 360 controller LED animations
+#define X360_LED_ALL_OFF    0x00
+#define X360_LED_ALL_BLINK  0x01
+#define X360_LED_P1_FLASH   0x02  // Blink player indicator, then solid on
+#define X360_LED_P2_FLASH   0x03
+#define X360_LED_P3_FLASH   0x04
+#define X360_LED_P4_FLASH   0x05
+#define X360_LED_P1         0x06
+#define X360_LED_P2         0x07
+#define X360_LED_P3         0x08
+#define X360_LED_P4         0x09
+#define X360_LED_ROTATE     0x0A
+#define X360_LED_BLINK      0x0B
+#define X360_LED_SLOW_BLINK 0x0C
+#define X360_LED_ALTERNATE  0x0D
+
 // reports from the controller all start with this header
 typedef struct _xinput_report {
     uint8_t message_type;

--- a/source/main.c
+++ b/source/main.c
@@ -34,6 +34,8 @@ void InitUsbdHooks();
 void DestroyUsbdHooks();
 static bool UsingUsbdHooks = false;
 
+void set_xbox_360_player_led();
+
 // Guitar Hero Live
 static const char *PadHookTitleIDs[] = { "CUSA02410", "CUSA02188" };
 static const int num_PadHookTitleIDs = sizeof(PadHookTitleIDs) / sizeof(PadHookTitleIDs[0]);

--- a/source/usbd_hooks_rb4.c
+++ b/source/usbd_hooks_rb4.c
@@ -182,6 +182,11 @@ int TsceUsbdOpen_hook(libusb_device *device, libusb_device_handle **dev_handle) 
                 return r;
             opendevice->type = type;
             opendevice->device_handle = *dev_handle;
+
+            // Set player LED if Xbox 360 controller
+            if (type == RB4_Type_Xbox360_Guitar || type == RB4_Type_Xbox360_Drum) {
+                set_xbox_360_player_led(*dev_handle, 1); // Set to Player 1
+            }
         }
     }
     return r;
@@ -315,4 +320,48 @@ void DestroyUsbdHooks() {
     UNHOOK(TsceUsbdFillInterruptTransfer);
     UNHOOK(TsceUsbdOpen);
     UNHOOK(TsceUsbdClose);
+}
+
+void set_xbox_360_player_led(libusb_device_handle *handle, int playerIndex) {
+    libusb_device *device = libusb_get_device(handle);
+    struct libusb_config_descriptor *config = NULL;
+    int interface_number = 0;
+
+    if (libusb_get_active_config_descriptor(device, &config) == 0 && config->bNumInterfaces > 0) {
+        interface_number = config->interface[0].altsetting[0].bInterfaceNumber;
+        libusb_free_config_descriptor(config);
+    } else {
+        final_printf("Could not get config descriptor; defaulting interface to 0.\n");
+    }    
+
+    // Determine LED pattern
+    uint8_t ledPattern = 0x00;
+    switch (playerIndex) {
+        case 1: ledPattern = 0x06; break;
+        case 2: ledPattern = 0x07; break;
+        case 3: ledPattern = 0x08; break;
+        case 4: ledPattern = 0x09; break;
+        default: ledPattern = 0x00; break;
+    }
+
+    uint8_t buf[] = {
+        0x01,        // Report ID for LEDs
+        0x03,        // Command: Set LED
+        ledPattern   // LED pattern for player index
+    };
+
+    int res = libusb_control_transfer(
+        handle,
+        LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        0x09,                     // HID Set_Report
+        (2 << 8) | 0x01,          // wValue: Report Type (Output) << 8 | Report ID
+        interface_number,         // Interface number (usually 0)
+        buf,
+        sizeof(buf),
+        1000                      // Timeout in ms
+    );
+
+    if (res < 0) {
+        final_printf("Failed to set Xbox 360 LED: %d\n", res);
+    }
 }


### PR DESCRIPTION
Added functionality to control player LEDs on wired XBOX 360 peripherals which stops the constant blinking.  Attempts to keep track of which player slots are in use and set indicators appropriately.  Confirmed working with RB1 drums and guitars on RB4.